### PR TITLE
Remove SHA384 and SHA512

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ Here are all the primitives listed in the spec. The primitives with checked boxe
     - [X] DHKEM(secp256k1, HKDF-SHA256)
 * KDFs
     - [X] HKDF-SHA256
-    - [X] HKDF-SHA384
-    - [X] HKDF-SHA512
 * AEADs
     - [X] ChaCha20Poly1305
 

--- a/examples/client_server.rs
+++ b/examples/client_server.rs
@@ -17,7 +17,7 @@
 
 use bitcoin_hpke::{
     aead::{AeadTag, ChaCha20Poly1305},
-    kdf::HkdfSha384,
+    kdf::HkdfSha256,
     kem::SecpK256HkdfSha256,
     Deserializable, Kem as KemTrait, OpModeR, OpModeS, Serializable,
 };
@@ -29,7 +29,7 @@ const INFO_STR: &[u8] = b"example session";
 // These are the only algorithms we're gonna use for this example
 type Kem = SecpK256HkdfSha256;
 type Aead = ChaCha20Poly1305;
-type Kdf = HkdfSha384;
+type Kdf = HkdfSha256;
 
 // Initializes the server with a fresh keypair
 fn server_init() -> (<Kem as KemTrait>::PrivateKey, <Kem as KemTrait>::PublicKey) {

--- a/src/kat_tests.rs
+++ b/src/kat_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     aead::{Aead, ChaCha20Poly1305, ExportOnlyAead},
-    kdf::{HkdfSha256, HkdfSha384, HkdfSha512, Kdf as KdfTrait},
+    kdf::{HkdfSha256, Kdf as KdfTrait},
     kem::{self, Kem as KemTrait, SecpK256HkdfSha256, SharedSecret},
     op_mode::{OpModeR, PskBundle},
     setup::setup_receiver,
@@ -346,7 +346,7 @@ fn kat_test() {
         dispatch_testcase!(
             tv,
             (ChaCha20Poly1305, ExportOnlyAead),
-            (HkdfSha256, HkdfSha384, HkdfSha512),
+            (HkdfSha256),
             (SecpK256HkdfSha256)
         );
 

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -5,7 +5,7 @@ use crate::util::write_u16_be;
 use digest::{core_api::BlockSizeUser, Digest, OutputSizeUser};
 use generic_array::GenericArray;
 use hmac::SimpleHmac;
-use sha2::{Sha256, Sha384, Sha512};
+use sha2::Sha256;
 
 const VERSION_LABEL: &[u8] = b"HPKE-v1";
 
@@ -44,28 +44,6 @@ impl KdfTrait for HkdfSha256 {
 
     // RFC 9180 §7.2: HKDF-SHA256
     const KDF_ID: u16 = 0x0001;
-}
-
-/// The implementation of HKDF-SHA384
-pub struct HkdfSha384 {}
-
-impl KdfTrait for HkdfSha384 {
-    #[doc(hidden)]
-    type HashImpl = Sha384;
-
-    // RFC 9180 §7.2: HKDF-SHA384
-    const KDF_ID: u16 = 0x0002;
-}
-
-/// The implementation of HKDF-SHA512
-pub struct HkdfSha512 {}
-
-impl KdfTrait for HkdfSha512 {
-    #[doc(hidden)]
-    type HashImpl = Sha512;
-
-    // RFC 9180 §7.2: HKDF-SHA512
-    const KDF_ID: u16 = 0x0003;
 }
 
 // RFC 9180 §4.1

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -28,8 +28,8 @@ pub(crate) fn dhkex_gen_keypair<Kex: DhKeyExchange, R: CryptoRng + RngCore>(
         GenericArray::default();
     // Fill it with randomness
     csprng.fill_bytes(&mut ikm);
-    // Run derive_keypair with a nonsense ciphersuite. We use SHA-512 to satisfy any security level
-    Kex::derive_keypair::<crate::kdf::HkdfSha512>(b"31337", &ikm)
+    // Run derive_keypair with a nonsense ciphersuite. We use SHA-256 because it's bitcoin.
+    Kex::derive_keypair::<crate::kdf::HkdfSha256>(b"31337", &ikm)
 }
 
 /// Creates a pair of `AeadCtx`s without doing a key exchange


### PR DESCRIPTION
Bitcoin apps don't use them.

This removes some maintenance burden, but is fully supported by `bitcoin_hashes` if we wanted to add it back. 

Well, sha512 is used in BIP32 derivation but not in HPKE.

Not sure if this is necessary, but imo less code is better.